### PR TITLE
Support Darwin and AF_VSOCK.

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,4 +1,6 @@
-/examples/hvgoecho
+/examples/hvgoecho.darwin
+/examples/hvgoecho.linux
 /examples/hvgoecho.exe
-/examples/hvgostress
+/examples/hvgostress.darwin
+/examples/hvgostress.linux
 /examples/hvgostress.exe

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,34 +1,45 @@
 
-.PHONY: all hvstress hvgoecho
+.PHONY: all hvstress hvgoecho hvgostress hvgoecho
 
 all: hvgostress hvgoecho
 
-hvgostress: examples/hvgostress examples/hvgostress.exe
-hvgoecho: examples/hvgoecho examples/hvgoecho.exe
+hvgostress: examples/hvgostress.darwin examples/hvgostress.linux examples/hvgostress.exe
+hvgoecho: examples/hvgoecho.darwin examples/hvgoecho.linux examples/hvgoecho.exe
 
 
 DEPS:=$(wildcard hvsock/*.go)  Dockerfile Makefile
 
-examples/hvgostress: examples/hvgostress.go $(DEPS)
+examples/hvgostress.linux: examples/hvgostress.go examples/common_hvsock.go examples/common_vsock.go examples/common_linux.go $(DEPS)
 	docker build -t hvsock:build .
 	docker run -v $(PWD):/go -e GOOS=linux -e GOARCH=amd64 -t hvsock:build \
-		go build  --ldflags '-extldflags "-fno-PIC"' hvgostress.go
+		go build -o hvgostress.linux --ldflags '-extldflags "-fno-PIC"' hvgostress.go common_hvsock.go common_vsock.go common_linux.go
 
-examples/hvgostress.exe: examples/hvgostress.go $(DEPS)
+
+examples/hvgostress.darwin: examples/hvgostress.go examples/common_vsock.go examples/common_darwin.go $(DEPS)
+	docker build -t hvsock:build .
+	docker run -v $(PWD):/go -e GOOS=darwin -e GOARCH=amd64 -t hvsock:build \
+		go build -o hvgostress.darwin  --ldflags '-extldflags "-fno-PIC"' hvgostress.go common_vsock.go common_darwin.go
+
+examples/hvgostress.exe: examples/hvgostress.go examples/common_hvsock.go examples/common_windows.go $(DEPS)
 	docker build -t hvsock:build .
 	docker run -v $(PWD):/go -e GOOS=windows -e GOARCH=amd64 -t hvsock:build \
-		go build  hvgostress.go
+		go build hvgostress.go common_hvsock.go common_windows.go
 
-examples/hvgoecho: examples/hvgoecho.go $(DEPS)
+examples/hvgoecho.linux: examples/hvgoecho.go examples/common_hvsock.go examples/common_vsock.go examples/common_linux.go $(DEPS)
 	docker build -t hvsock:build .
 	docker run -v $(PWD):/go -e GOOS=linux -e GOARCH=amd64 -t hvsock:build \
-		go build  --ldflags '-extldflags "-fno-PIC"' hvgoecho.go
+		go build -o hvgoecho.linux  --ldflags '-extldflags "-fno-PIC"' hvgoecho.go common_hvsock.go common_vsock.go common_linux.go
 
-examples/hvgoecho.exe: examples/hvgoecho.go $(DEPS)
+examples/hvgoecho.darwin: examples/hvgoecho.go examples/common_vsock.go examples/common_darwin.go $(DEPS)
+	docker build -t hvsock:build .
+	docker run -v $(PWD):/go -e GOOS=darwin -e GOARCH=amd64 -t hvsock:build \
+		go build -o hvgoecho.darwin  --ldflags '-extldflags "-fno-PIC"' hvgoecho.go common_vsock.go common_darwin.go
+
+examples/hvgoecho.exe: examples/hvgoecho.go examples/common_hvsock.go examples/common_windows.go $(DEPS)
 	docker build -t hvsock:build .
 	docker run -v $(PWD):/go -e GOOS=windows -e GOARCH=amd64 -t hvsock:build \
-		go build  hvgoecho.go
+		go build hvgoecho.go common_hvsock.go common_windows.go
 
 clean:
-	rm examples/hvgostress examples/hvgostress.exe
-	rm examples/hvgoecho examples/hvgoecho.exe
+	rm -f examples/hvgostress.darwin examples/hvgostress.linux examples/hvgostress.exe
+	rm -f examples/hvgoecho.darwin examples/hvgoecho.linux examples/hvgoecho.exe

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,61 @@
+_Note:_ `hvgoecho` can be substituted for `hvgostress` mostly as is
+(the basic options are common to both).
+
+# Operating System Specific
+
+## Windows
+
+TBD
+
+## Linux
+
+After building the binary can be run from a suitably privileged
+container:
+
+    $ cat >Dockerfile <<EOF
+    FROM alpine
+    RUN apk update && apk add strace
+    ADD hvgostress.linux /hvgostress
+    ENTRYPOINT ["/hvgostress"]
+    EOF
+    $ docker build -t stress . && docker run -it --rm --net=host --privileged stress [...options...]
+
+## MacOS
+
+Under MacOS the default is to assume Hyperkit as configured by Docker
+for Mac (since the path to the sockets and the names of the sockets
+themselves differ).
+
+To run against standalone Hyperkit the path to the sockets must be
+specified when starting Hyperkit and must be passed to the option:
+
+    macos$ ./hvgostress.darwin -s -m hyperkit:/var/run/
+
+(this assumes hyperkit was built without `PRI_ADDR_PREFIX` or
+`CONNECT_SOCKET_NAME` set at build time and run with e.g. `-s
+7,virtio-sock,guest_cid=3,path=/var/run`)
+
+In Docker mode everything is implied to be as it is configured by
+Docker 4 Mac. This is the default but can be given explicitly with:
+
+    macos$ ./hvgostress.darwin -s -m docker
+
+# Specific OS Pairs
+
+## Linux & Docker for Windows
+
+TBD
+
+## Linux & Docker for Mac
+
+When running as a client on the Linux side the correct address is cid
+"2" (the host):
+
+    linux$ docker run -it --rm --net=host --privileged stress -c 2
+    macos$ ./hvgostress.darwin -s
+
+When running as a client on the MacOS side the correct address is cid
+is "3" (the guest, as configued by Docker for Mac):
+
+    linux$ docker run -it --rm --net=host --privileged stress -s
+    macos$ ./hvgostress.darwin -c 3

--- a/go/examples/common_darwin.go
+++ b/go/examples/common_darwin.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	socketMode string
+
+	socketPath  string
+	connectPath string
+	socketFmt   string
+)
+
+func init() {
+	flag.StringVar(&socketMode, "m", "docker", "Socket Mode (hyperkit:/path/ or docker)")
+}
+
+func SetVerbosity() {}
+
+func ValidateOptions() {
+	if strings.HasPrefix(socketMode, "hyperkit:") {
+		socketPath = socketMode[len("hyperkit:"):]
+		connectPath = filepath.Join(socketPath, "connect")
+		socketFmt = "%08x.%08x"
+	} else if socketMode == "docker" {
+		socketPath = filepath.Join(os.Getenv("HOME"), "/Library/Containers/com.docker.docker/Data")
+		connectPath = filepath.Join(socketPath, "@connect")
+		socketFmt = "*%08x.%08x"
+	} else {
+		log.Fatalln("Unknown socket mode: ", socketMode)
+	}
+}
+
+type vsockClient struct {
+	cid uint
+}
+
+func ParseClientStr(clientStr string) Client {
+	cid := VsockParseClientStr(clientStr)
+	return &vsockClient{cid}
+}
+
+func (cl vsockClient) String() string {
+	return fmt.Sprintf("%08x.%08x", cl.cid, vsockPort)
+}
+
+func (cl vsockClient) Dial(conid int) (Conn, error) {
+	c, err := net.DialUnix("unix", nil, &net.UnixAddr{connectPath, "unix"})
+	if err != nil {
+		return c, err
+	}
+	if _, err := fmt.Fprintf(c, "%s\n", cl.String()); err != nil {
+		return c, fmt.Errorf("Failed to write dest (%s) to %s", cl, connectPath)
+	}
+	return c, nil
+}
+
+func ServerListen() net.Listener {
+	sock := filepath.Join(socketPath, fmt.Sprintf(socketFmt, 2, vsockPort))
+	if err := os.Remove(sock); err != nil && !os.IsNotExist(err) {
+		log.Fatalln("Listen(): Remove:", err)
+	}
+
+	l, err := net.ListenUnix("unix", &net.UnixAddr{sock, "unix"})
+	if err != nil {
+		log.Fatalln("Listen():", err)
+	}
+	return l
+}

--- a/go/examples/common_hvsock.go
+++ b/go/examples/common_hvsock.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"log"
+	"net"
+	"strings"
+
+	"../hvsock"
+)
+
+var (
+	svcid, _ = hvsock.GuidFromString("3049197C-9A4E-4FBF-9367-97F792F16994")
+)
+
+func HvsockSetVerbosity() {
+	if verbose > 2 {
+		hvsock.Debug = true
+	}
+}
+
+type hvsockClient struct {
+	vmid hvsock.GUID
+}
+
+func HvsockParseClientStr(clientStr string) hvsockClient {
+	vmid := hvsock.GUID_ZERO
+	var err error
+	if strings.Contains(clientStr, "-") {
+		vmid, err = hvsock.GuidFromString(clientStr)
+		if err != nil {
+			log.Fatalln("Can't parse GUID: ", clientStr)
+		}
+	} else if clientStr == "parent" {
+		vmid = hvsock.GUID_PARENT
+	} else {
+		vmid = hvsock.GUID_LOOPBACK
+	}
+
+	return hvsockClient{vmid}
+}
+
+func (cl hvsockClient) String() string {
+	return cl.vmid.String()
+}
+
+func (cl hvsockClient) Dial(conid int) (Conn, error) {
+	sa := hvsock.HypervAddr{VmId: cl.vmid, ServiceId: svcid}
+	return hvsock.Dial(sa)
+}
+
+func HvsockServerListen() net.Listener {
+	l, err := hvsock.Listen(hvsock.HypervAddr{VmId: hvsock.GUID_WILDCARD, ServiceId: svcid})
+	if err != nil {
+		log.Fatalln("Listen():", err)
+	}
+
+	return l
+}

--- a/go/examples/common_linux.go
+++ b/go/examples/common_linux.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"../vsock"
+)
+
+var (
+	socketMode string
+)
+
+func init() {
+	flag.StringVar(&socketMode, "m", "", "Socket Mode (vsock or hvsock)")
+}
+
+func SetVerbosity() {
+	HvsockSetVerbosity()
+	//VsockSetVerbosity() // No verbosity settings there, yet
+}
+
+func ValidateOptions() {
+	if socketMode == "" {
+		if _, err := os.Stat("/sys/bus/vmbus"); err != nil && os.IsNotExist(err) {
+			socketMode = "vsock"
+		} else {
+			socketMode = "hvsock"
+		}
+	}
+	if socketMode != "hvsock" && socketMode != "vsock" {
+		log.Fatalln("Unknown socket mode: ", socketMode)
+	}
+}
+
+type vsockClient struct {
+	cid uint
+}
+
+func ParseClientStr(clientStr string) Client {
+	if socketMode == "hvsock" {
+		return HvsockParseClientStr(clientStr)
+	} else if socketMode == "vsock" {
+		cid := VsockParseClientStr(clientStr)
+		return &vsockClient{cid}
+	}
+	panic("socketMode")
+}
+
+func (cl vsockClient) String() string {
+	return fmt.Sprintf("%08x.%08x", cl.cid, vsockPort)
+}
+
+func (cl vsockClient) Dial(conid int) (Conn, error) {
+	return vsock.Dial(cl.cid, vsockPort)
+}
+
+func ServerListen() net.Listener {
+	if socketMode == "hvsock" {
+		return HvsockServerListen()
+	} else if socketMode != "vsock" {
+		panic("socketMode")
+	}
+
+	l, err := vsock.Listen(vsockPort)
+	if err != nil {
+		log.Fatalln("Listen():", err)
+	}
+	return l
+}

--- a/go/examples/common_vsock.go
+++ b/go/examples/common_vsock.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"strconv"
+)
+
+const (
+	vsockPort = 0x5653
+)
+
+func VsockParseClientStr(clientStr string) uint {
+	cid, err := strconv.ParseUint(clientStr, 10, 32)
+	if err != nil {
+		log.Fatalf("Can't convert %s to a uint.", clientStr, err)
+	}
+	return uint(cid)
+}

--- a/go/examples/common_windows.go
+++ b/go/examples/common_windows.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net"
+)
+
+func SetVerbosity() {
+	HvsockSetVerbosity()
+}
+
+func ValidateOptions() {}
+
+func ParseClientStr(clientStr string) Client {
+	return HvsockParseClientStr(clientStr)
+}
+
+func ServerListen() net.Listener {
+	return HvsockServerListen()
+}

--- a/go/examples/hvgoecho.go
+++ b/go/examples/hvgoecho.go
@@ -92,7 +92,8 @@ func client(cl Client) {
 	}
 	fmt.Printf("Sent: %d bytes\n", l)
 
-	message, err := bufio.NewReader(c).ReadString('\n')
+	reader := bufio.NewReader(c)
+	message, err := reader.ReadString('\n')
 	if err != nil {
 		log.Fatalln("Failed to receive: ", err)
 	}
@@ -102,7 +103,7 @@ func client(cl Client) {
 	c.CloseWrite()
 
 	fmt.Printf("Waiting for Bye message\n")
-	message, err = bufio.NewReader(c).ReadString('\n')
+	message, err = reader.ReadString('\n')
 	if err != nil {
 		log.Fatalln("Failed to receive: ", err)
 	}

--- a/go/examples/hvgoecho.go
+++ b/go/examples/hvgoecho.go
@@ -7,28 +7,33 @@ import (
 	"io"
 	"log"
 	"net"
-	"strings"
-
-	"../hvsock"
 )
 
 var (
 	clientStr  string
 	serverMode bool
-
-	svcid, _ = hvsock.GuidFromString("3049197C-9A4E-4FBF-9367-97F792F16994")
+	verbose    int
 )
+
+type Conn interface {
+	net.Conn
+	CloseRead() error
+	CloseWrite() error
+}
+
+type Client interface {
+	String() string
+	Dial(conid int) (Conn, error)
+}
 
 func init() {
 	flag.StringVar(&clientStr, "c", "", "Client")
 	flag.BoolVar(&serverMode, "s", false, "Start as a Server")
+	flag.IntVar(&verbose, "v", 0, "Set the verbosity level")
 }
 
 func server() {
-	l, err := hvsock.Listen(hvsock.HypervAddr{VmId: hvsock.GUID_WILDCARD, ServiceId: svcid})
-	if err != nil {
-		log.Fatalln("Listen():", err)
-	}
+	l := ServerListen()
 	defer func() {
 		l.Close()
 	}()
@@ -68,11 +73,10 @@ func handleRequest(c net.Conn) {
 	fmt.Printf("Sent bye\n")
 }
 
-func client(vmid hvsock.GUID) {
-	sa := hvsock.HypervAddr{VmId: vmid, ServiceId: svcid}
-	c, err := hvsock.Dial(sa)
+func client(cl Client) {
+	c, err := cl.Dial(0)
 	if err != nil {
-		log.Fatalln("Failed to Dial:\n", sa.VmId.String(), sa.ServiceId.String(), err)
+		log.Fatalln("Failed to Dial:\n", cl.String(), err)
 	}
 
 	defer func() {
@@ -109,23 +113,15 @@ func main() {
 	log.SetFlags(log.LstdFlags)
 	flag.Parse()
 
+	ValidateOptions()
+
 	if serverMode {
 		fmt.Printf("Starting server\n")
 		server()
 	}
 
-	vmid := hvsock.GUID_ZERO
-	var err error
-	if strings.Contains(clientStr, "-") {
-		vmid, err = hvsock.GuidFromString(clientStr)
-		if err != nil {
-			log.Fatalln("Can't parse GUID: ", clientStr)
-		}
-	} else if clientStr == "parent" {
-		vmid = hvsock.GUID_PARENT
-	} else {
-		vmid = hvsock.GUID_LOOPBACK
-	}
-	fmt.Printf("Client connecting to %s", vmid.String())
-	client(vmid)
+	cl := ParseClientStr(clientStr)
+
+	fmt.Printf("Client connecting to %s", cl.String())
+	client(cl)
 }

--- a/go/examples/hvgostress.go
+++ b/go/examples/hvgostress.go
@@ -183,7 +183,8 @@ func client(cl Client, conid int) {
 
 	rxbuf := make([]byte, buflen)
 
-	n, err := io.ReadFull(bufio.NewReader(c), rxbuf)
+	reader := bufio.NewReader(c)
+	n, err := io.ReadFull(reader, rxbuf)
 	if err != nil {
 		prError("[%05d] Failed to receive: %s\n", conid, err)
 		return
@@ -198,7 +199,7 @@ func client(cl Client, conid int) {
 	}
 
 	// Wait for Bye message
-	message, err := bufio.NewReader(c).ReadString('\n')
+	message, err := reader.ReadString('\n')
 	if err != nil {
 		prError("[%05d] Failed to receive bye: %s\n", conid, err)
 	}


### PR DESCRIPTION
Significantly refactor to support vsock and Darwin. Matrix is:

```
        | hvsock | vsock |
--------+--------+-------+
Darwin  |        |   X   |
Linux   |   X    |   X   |
Windows |   X    |       |
```

Linux tries to autodetect AF_VSOCK vs AF_HYPERV but can be overridden with `-m
vsock` or `-m hvsock`.

Darwin assumes Hyperkit as configured by Docker for Mac, but can be overridden
with e.g. `-m hyperkit:/some/path` for standalone hyperkit.

Add a README to explain how to run things. Note that I have only build tested
for Windows and it remains undocumented.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>