### PR TITLE
Support for larger (and very large) buffers in hvgostress

### DIFF
--- a/go/examples/hvgostress.go
+++ b/go/examples/hvgostress.go
@@ -19,6 +19,7 @@ var (
 	clientStr   string
 	serverMode  bool
 	maxDataLen  int
+	minDataLen  int
 	connections int
 	sleepTime   int
 	verbose     int
@@ -42,6 +43,7 @@ type Client interface {
 func init() {
 	flag.StringVar(&clientStr, "c", "", "Client")
 	flag.BoolVar(&serverMode, "s", false, "Start as a Server")
+	flag.IntVar(&minDataLen, "L", 0, "Minimum Length of data")
 	flag.IntVar(&maxDataLen, "l", 64*1024, "Maximum Length of data")
 	flag.IntVar(&connections, "i", 100, "Total number of connections")
 	flag.IntVar(&sleepTime, "w", 0, "Sleep time in seconds between new connections")
@@ -65,6 +67,10 @@ func main() {
 		return
 	}
 
+	if minDataLen > maxDataLen {
+		fmt.Printf("minDataLen > maxDataLen!")
+		return
+	}
 	cl := ParseClientStr(clientStr)
 
 	if parallel <= 1 {
@@ -159,7 +165,10 @@ func client(cl Client, conid int) {
 
 	// Create buffer with random data and random length.
 	// Make sure the buffer is not zero-length
-	buflen := rand.Intn(maxDataLen-1) + 1
+	buflen := minDataLen
+	if maxDataLen > minDataLen {
+		buflen += rand.Intn(maxDataLen - minDataLen + 1)
+	}
 	txbuf := randBuf(buflen)
 	csum0 := md5.Sum(txbuf)
 

--- a/go/examples/hvgostress.go
+++ b/go/examples/hvgostress.go
@@ -196,6 +196,9 @@ func client(cl Client, conid int) {
 	}
 	hash0 := md5.New()
 
+	var txTime, rxTime time.Duration
+	start := time.Now()
+
 	w := make(chan int)
 	go func() {
 		total := 0
@@ -231,6 +234,7 @@ func client(cl Client, conid int) {
 		// Tell the other end that we are done
 		c.CloseWrite()
 
+		txTime = time.Since(start)
 		w <- total
 	}()
 
@@ -267,13 +271,14 @@ func client(cl Client, conid int) {
 		totalReceived += l
 	}
 
+	rxTime = time.Since(start)
 	totalSent := <-w
 
 	csum0 := md5Hash(hash0)
-	prDebug("[%05d] TX: %d bytes, md5=%02x\n", conid, totalSent, csum0)
+	prDebug("[%05d] TX: %d bytes, md5=%02x in %s\n", conid, totalSent, csum0, txTime)
 
 	csum1 := md5Hash(hash1)
-	prInfo("[%05d] RX: %d bytes, md5=%02x (sent=%d)\n", conid, totalReceived, csum1, totalSent)
+	prInfo("[%05d] RX: %d bytes, md5=%02x in %s (sent=%d)\n", conid, totalReceived, csum1, rxTime, totalSent)
 	if csum0 != csum1 {
 		prError("[%05d] Checksums don't match", conid)
 	}


### PR DESCRIPTION
The current implementation does not allow for very large buffers since the client side does both Rx and Tx into static local buffers, meaning that testing with e.g. 4G of data is going to take ~8G of memory (and/or swap like mad).

This PR improves things in this use case by:

* Adding a lower bound to the randomly selected data size, so you can constrain to e.g. 4-5G rather than just 0-5G, meaning you can concentrate testing on the larger sizes if you want to.
* Doing both Tx and Rx on the client side in randomly sized batches (also with configurable min and max). Note that the server side still uses `io.Copy` and hence a buffer of implementation defined (and likely static) size.
* Measuring and reporting the duration (really just for interest)

It also detects Tx and Rx hangs on the client side (which doesn't really relate to using larger buffers but I had an itch).