### PR TITLE
vsock: Add Conn.File() to get underlying file

### DIFF
--- a/pkg/vsock/vsock.go
+++ b/pkg/vsock/vsock.go
@@ -14,6 +14,7 @@ package vsock
 import (
 	"fmt"
 	"net"
+	"os"
 )
 
 const (
@@ -46,4 +47,5 @@ type Conn interface {
 	net.Conn
 	CloseRead() error
 	CloseWrite() error
+	File() (*os.File, error)
 }

--- a/pkg/vsock/vsock_linux.go
+++ b/pkg/vsock/vsock_linux.go
@@ -1,4 +1,5 @@
 // Bindings to the Linux hues interface to VM sockets.
+
 package vsock
 
 import (
@@ -157,4 +158,14 @@ func (v *VsockConn) SetReadDeadline(t time.Time) error {
 // SetWriteDeadline sets the deadline for future Write calls
 func (v *VsockConn) SetWriteDeadline(t time.Time) error {
 	return nil // FIXME
+}
+
+// File duplicates the underlying socket descriptor and returns it.
+func (v *VsockConn) File() (*os.File, error) {
+	// This is equivalent to dup(2) but creates the new fd with CLOEXEC already set.
+	r0, _, e1 := syscall.Syscall(syscall.SYS_FCNTL, uintptr(v.vsock.Fd()), syscall.F_DUPFD_CLOEXEC, 0)
+	if e1 != 0 {
+		return nil, os.NewSyscallError("fcntl", e1)
+	}
+	return os.NewFile(r0, v.vsock.Name()), nil
 }


### PR DESCRIPTION
This method, which is also supported by net.TCPConn and net.UnixConn,
allows the caller to get an os.File from the connection.