### PR TITLE
Update LinuxKit bits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bin/sock_stress.exe: $(DEPS)
 linuxkit: build-in-container Dockerfile.linuxkit hvtest.yml
 	$(MAKE) -C c build-in-container
 	docker build -t hvtest-local -f Dockerfile.linuxkit .
-	moby build -format kernel+initrd,iso-efi hvtest.yml
+	linuxkit build -format kernel+initrd,iso-efi hvtest.yml
 
 clean:
 	rm -rf bin c/build

--- a/hvtest.yml
+++ b/hvtest.yml
@@ -1,20 +1,21 @@
 kernel:
   # Choose your kernel
-  image: linuxkit/kernel:4.14.6
+  image: linuxkit/kernel:4.14.15
   cmdline: "console=ttyS0"
 init:
-  - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4
-  - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
-  - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
+  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
+  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
+  - linuxkit/ca-certificates:v0.2
   - hvtest-local
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:ce3bde5118a41092f1b7048c85d14fb35237ed45
+    image: linuxkit/sysctl:v0.2
 services:
   - name: rngd
-    image: linuxkit/rngd:94e01a4b16fadb053455cdc2269c4eb0b39199cd
+    image: linuxkit/rngd:v0.2
   - name: getty
-    image: linuxkit/getty:22e27189b6b354e1d5d38fc0536a5af3f2adb79f
+    image: linuxkit/getty:v0.2
     binds:
       - /usr/bin/sock_stress:/usr/bin/sock_stress
       - /tmp:/tmp


### PR DESCRIPTION
- Use linuxkit build instead of moby build
- Update YAML to relased components (mostly)

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>