### PR TITLE
linuxkit: Tweak the linuxkit image

### DIFF
--- a/hvtest.yml
+++ b/hvtest.yml
@@ -1,12 +1,13 @@
 kernel:
   # Choose your kernel
-  image: linuxkit/kernel:4.14.15
+  image: linuxkit/kernel:4.14.18
   cmdline: "console=ttyS0"
+  tar: none
 init:
-  - linuxkit/init:e650be6c21ef9ecb33534858fc63fb8bc5028c6e
+  - linuxkit/init:6061875ba11fd9c563fda6234b103ed9997ff782
   - linuxkit/runc:52ecfdef1ae051e7fd5ac5f1d0b7dd859adff015
-  - linuxkit/containerd:f5c339dfc54645eeb8c635b77f62b05a8b3a4db6
-  - linuxkit/ca-certificates:v0.2
+  - linuxkit/containerd:13f62c61f0465fb07766d88b317cabb960261cbb
+  - linuxkit/kernel-perf:4.14.18
   - hvtest-local
 onboot:
   - name: sysctl
@@ -17,7 +18,11 @@ services:
   - name: getty
     image: linuxkit/getty:v0.2
     binds:
+      - /usr/bin/perf:/usr/bin/perf
       - /usr/bin/sock_stress:/usr/bin/sock_stress
+      - /usr/bin/hvbench:/usr/bin/hvbench
+      - /usr/bin/hvecho:/usr/bin/hvecho
+      - /usr/bin/hvstress:/usr/bin/hvstress
       - /tmp:/tmp
       - /etc:/hostroot/etc
       - /var/log:/var/log


### PR DESCRIPTION
- Don't include kernel modules. They are not needed.
- Update kernel tp 4.14.18.
- Add perf utility.
- Create bind mounts in getty container for all utilities.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>