### PR TITLE
hvsock: Fix issue with 4.16.x and newer kernels

### DIFF
--- a/pkg/hvsock/hvsock_linux.go
+++ b/pkg/hvsock/hvsock_linux.go
@@ -30,7 +30,7 @@ int connect_sockaddr_hv(int fd, const struct sockaddr_hv *sa_hv) {
     return connect(fd, (const struct sockaddr*)sa_hv, sizeof(*sa_hv));
 }
 int accept_hv(int fd, struct sockaddr_hv *sa_hv, socklen_t *sa_hv_len) {
-    return accept4(fd, (struct sockaddr *)sa_hv, sa_hv_len, 0);
+    return accept(fd, (struct sockaddr *)sa_hv, sa_hv_len);
 }
 int getsockname_hv(int fd, struct sockaddr_hv *sa_hv, socklen_t *sa_hv_len) {
     return getsockname(fd, (struct sockaddr *)sa_hv, sa_hv_len);

--- a/pkg/hvsock/hvsock_linux.go
+++ b/pkg/hvsock/hvsock_linux.go
@@ -32,6 +32,9 @@ int connect_sockaddr_hv(int fd, const struct sockaddr_hv *sa_hv) {
 int accept_hv(int fd, struct sockaddr_hv *sa_hv, socklen_t *sa_hv_len) {
     return accept4(fd, (struct sockaddr *)sa_hv, sa_hv_len, 0);
 }
+int getsockname_hv(int fd, struct sockaddr_hv *sa_hv, socklen_t *sa_hv_len) {
+    return getsockname(fd, (struct sockaddr *)sa_hv, sa_hv_len);
+}
 */
 import "C"
 
@@ -53,6 +56,9 @@ const (
 
 // Supported returns if hvsocks are supported on your platform
 func Supported() bool {
+	var sa C.struct_sockaddr_hv
+	var sa_len C.socklen_t
+
 	// Try opening  a hvsockAF socket. If it works we are on older, i.e. 4.9.x kernels.
 	// 4.11 defines AF_SMC as 43 but it doesn't support protocol 1 so the
 	// socket() call should fail.
@@ -60,7 +66,16 @@ func Supported() bool {
 	if err != nil {
 		return false
 	}
+
+	// 4.16 defines SMCPROTO_SMC6 as 1 but its socket name size doesn't match
+	// size of sockaddr_hv so corresponding check should fail.
+	sa_len = C.sizeof_struct_sockaddr_hv
+	ret, _ := C.getsockname_hv(C.int(fd), &sa, &sa_len)
 	syscall.Close(fd)
+	if ret < 0 || sa_len != C.sizeof_struct_sockaddr_hv {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Kernel 4.16 introduces SMC IPv6 protocol, defines SMCPROTO_SMC6 as 1.
So, ```socket(43 /* AF_HYPERV */, SOCK_STREAM, 1 /* HV_PROTOCOL_RAW */)```
does no longer fail, gives false-positive presense of Hyper-V socket
support.

Fix this by getting and checking exact socket name size, it should be
different for AF_SMC/SMCPROTO_SMC6 and AF_HYPERV/HV_PROTOCOL_RAW.

Also, non-standard Linux extension accept4() required _GNU_SOURCE to be defined.
If not, following warnings are expected:
    hvsock_linux.go: In function ‘accept_hv’:
    hvsock_linux.go:33:12: warning: implicit declaration of function ‘accept4’

If flags is 0 then accept4() is the same as accept(), so in this case let's
use accept() and get rid of warnings.